### PR TITLE
1.17.0 - add standard teachable font families to font family list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,11 +4,12 @@
     "angular-redactor-filepicker.js",
     "./src/redactor.css"
   ],
-  "version": "1.16.0",
+  "version": "1.17.0",
   "homepage": "https://github.com/UseFedora/angular-redactor-filepicker-bundle",
   "authors": [
     "Tyler Garlick <tjgarlick@gmail.com>",
-    "Noah Pryor <noah@noahpryor.com>"
+    "Noah Pryor <noah@noahpryor.com>",
+    "Michael Poage <poage.michael.cu@gmail.com>"
   ],
   "description": "Directive for redactor WYSIWYG editor with filepicker, get a license",
   "keywords": [

--- a/src/redactor-fontfamily.js
+++ b/src/redactor-fontfamily.js
@@ -6,7 +6,22 @@
     return {
       init: function ()
       {
-        var fonts = [ 'Arial', 'Helvetica', 'Georgia', 'Times New Roman', 'Monospace' ];
+        var fonts = [
+          'Arial',
+          'Helvetica',
+          'Georgia',
+          'Times New Roman',
+          'Monospace',
+          'Proxima',
+          'Alegreya',
+          'Lato',
+          'Lucida Sans Unicode',
+          'Merriweather',
+          'OpenSans',
+          'Palatino',
+          'Raleway',
+          'SourceSansPro'
+        ];
         var that = this;
         var dropdown = {};
 
@@ -15,7 +30,7 @@
           dropdown['s' + i] = { title: s, func: function() { that.fontfamily.set(s); }};
         });
 
-        dropdown.remove = { title: 'Remove Font Family', func: that.fontfamily.reset };
+        dropdown.remove = { title: 'Use Default Font', func: that.fontfamily.reset };
 
         var button = this.button.add('fontfamily', 'Change Font Family');
         this.button.addDropdown(button, dropdown);


### PR DESCRIPTION
This adds in all of the standard Teachable Fonts that we use in the Site -> Theme section of the app to maintain consistency. Also change the Remove Font Family text to read Use Default Font to make it clear that it will revert to whatever font family is set globally for tags on that page.