### PR TITLE
[ENABLE-239] use usefedora package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@usefedora:registry=https://npm.pkg.github.com/usefedora

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@usefedora/angular-redactor-filepicker",
-  "version": "0.0.6-alpha.1",
+  "version": "0.0.7",
   "description": "teachable.com build of redactor",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/UseFedora/angular-redactor.git"
+    "url": "git+https://github.com/UseFedora/angular-redactor-filepicker.git"
   },
   "license": "NONE",
   "bugs": {
-    "url": "https://github.com/UseFedora/angular-redactor/issues"
+    "url": "https://github.com/UseFedora/angular-redactor-filepicker/issues"
   },
-  "homepage": "https://github.com/UseFedora/angular-redactor#readme",
+  "homepage": "https://github.com/UseFedora/angular-redactor-filepicker#readme",
   "devDependencies": {
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@teachable/angular-redactor-filepicker",
-  "version": "0.0.6",
+  "name": "@usefedora/angular-redactor-filepicker",
+  "version": "0.0.6-alpha.1",
   "description": "teachable.com build of redactor",
   "main": "gulpfile.js",
   "repository": {


### PR DESCRIPTION
Turns out that this is the package that fedora uses (there were three candidate repos 😭 ), so this pr moves it over to the `@usefedora` namespace (and by extension the gh packages). The package can be seen [here](https://github.com/UseFedora/angular-redactor-filepicker-bundle/packages/1210324).

testing it out in this PR: https://github.com/UseFedora/fedora/pull/20758